### PR TITLE
Integrate Druidoo

### DIFF
--- a/templates/adhoc-odoo/17/README.md
+++ b/templates/adhoc-odoo/17/README.md
@@ -1,0 +1,31 @@
+## ADHOC Odoo 9.0
+
+Deploy Odoo
+
+### Provides
+
+Production Odoo instance with Rancher health checks.
+
+### Configuration Items
+
+ * strServerMode: set env variable SERVER_MODE. default empty
+ * intWorkers: set env variable WORKERS (better if integer validation). Default=0. Required
+ * strAdminPassword: set env variable ADMIN_PASSWORD. Default 'admin', required
+ * boolWithoutDemo: set env variable WITHOUT_DEMO, default True
+
+
+SOBRE EL SIDEKICK
+    # agregamos esto de las sesiones para que cuando actualizamos la gente no quede deslogeada
+    # no lo montamos a todo el data directamente porque en teoría las sesiones deberian tener buena performance
+
+# image: alpine:3.6
+        # image: adhoc/odoo-ar-e:9.0
+        # TODO, habria que mejorarlo para nodar permiso 777
+        # bash -c "chown -R www-data. application; chown -R www-data. packages; sleep 2m; php -f concrete/bin/concrete5.php c5:install --db-server=mysql --db-username=${db_username} --db-password=${db_password} --db-database=${db_name} --site=${cms_sitename} --admin-email=${cms_admin_email} --admin-password=${cms_admin_password} -n -vvv"
+        # alpine no tiene el bash, va sh
+        # command: sh -c "adduser -S -D odoo; chown -R odoo.odoo /opt/odoo/data/sessions"
+        # probe como hace rawmind y distintas maneras pero no consegui permiso de escritura en la carpeta sessions
+        # la unica fue esta del command
+
+                # command: bash -c "chmod 777 -R /opt/odoo/data/sessions"
+        # command: chmod 777 -R /opt/odoo/data/sessions

--- a/templates/adhoc-odoo/17/README.md
+++ b/templates/adhoc-odoo/17/README.md
@@ -1,4 +1,4 @@
-## ADHOC Odoo 9.0
+## Odoo SaaS 12.0
 
 Deploy Odoo
 

--- a/templates/adhoc-odoo/17/docker-compose.yml.tpl
+++ b/templates/adhoc-odoo/17/docker-compose.yml.tpl
@@ -1,0 +1,107 @@
+version: '2'
+services:
+    odoo:
+        tty: true
+        stdin_open: true
+        image: $strImageName:$strImageTag
+        labels:
+            io.rancher.scheduler.affinity:container_label_soft_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
+            io.rancher.scheduler.affinity:host_label: ${host_label}
+            traefik.enable: true
+            traefik.port: 8069
+            traefik.backend.loadbalancer.stickiness: true
+            traefik.backend.loadbalancer.method: drr
+            {{- if ne .Values.strGCECloudsqlConnectionName "" }}
+            io.rancher.sidekicks: gce-psql-proxy
+            {{- end}}
+        {{- if eq .Values.intWorkers "0"}}
+            traefik.frontend.rule: Host:$strTraefikDomains
+            traefik.frontend.redirect.regex: $strTraefikRedirectRegex
+            traefik.frontend.redirect.replacement: $strTraefikRedirectReplacement
+            traefik.frontend.redirect.permanent: true
+        {{- else}}
+            traefik.odoo.port: 8069
+            traefik.odoo.frontend.rule: Host:$strTraefikDomains
+            traefik.odoo.frontend.redirect.regex: $strTraefikRedirectRegex
+            traefik.odoo.frontend.redirect.replacement: $strTraefikRedirectReplacement
+            traefik.odoo.frontend.redirect.permanent: true
+            traefik.longpolling.port: 8072
+            traefik.longpolling.frontend.rule: Host:$strTraefikDomains;PathPrefix:/longpolling/
+            traefik.longpolling.frontend.redirect.regex: $strTraefikRedirectRegex
+            traefik.longpolling.frontend.redirect.replacement: $strTraefikRedirectReplacement
+            traefik.longpolling.frontend.redirect.permanent: true
+        {{- end}}
+        volumes:
+            - $strOdooFilestoreVolumeName:$strOdooDataFilestore
+            {{- if eq .Values.enumSessionsStore "filestore" }}
+            - $strOdooSessionsVolumeName:$strOdooDataSessions
+            {{- end}}
+        environment:
+            # database parameters
+            - PGUSER=$strPgUser
+            - PGPASSWORD=$strPgPassword
+            - PGHOST=$strPgHost
+            - PGPORT=$strPgPort
+            - PGDATABASE=$strDatabase
+            - DATABASE=$strDatabase
+            - DBFILTER=$strDbFilter
+            - LIST_DB=$boolListDb
+            - DB_MAXCONN=$intDbMaxconn
+            # TODO, este podria volver a ser un booleano y tmb podriamos
+            # re simplificar el entry point, ahora modificamos a odoo para que
+            # no cree bd si se manda el db_name, y estamos haciendo eso, mandar
+            # db_name
+            - FIXDBS=$strFixDbs
+            - FIXDBS_ADHOC=$strFixDbsAdhoc
+            - FIX_DB_WEB_DISABLED=True
+            - SMTP_SERVER=$strSmtpServer
+            - SMTP_PORT=$intSmtPort
+            - SMTP_SSL=$boolSmtpSsl
+            - SMTP_USER=$strSmtpUser
+            - SMTP_PASSWORD=$strSmtPassword
+            - AEROO_DOCS_HOST= aeroo-docs.adhoc-aeroo-docs
+            - ADMIN_PASSWORD=$strAdminPassword
+            - WORKERS=$intWorkers
+            - UNACCENT=True
+            - PROXY_MODE=True
+            - WITHOUT_DEMO=True
+            - WAIT_PG=True
+            - MAX_CRON_THREADS=$intMaxCronThreads
+            - SERVER_MODE=$strServerMode
+            - DISABLE_SESSION_GC=$strDisableSessionGC
+            - MAIL_CATCHALL_DOMAIN=$strMailCatchallDomain
+            - REPOS_YML=$strReposYml
+            - LIMIT_MEMORY_HARD=$intLimitMemoryHard
+            - LIMIT_MEMORY_SOFT=$intLimitMemorySoft
+            - LIMIT_TIME_CPU=$intLimiteTimeCpu
+            - LIMIT_TIME_REAL=$intLimiteTimeReal
+            - LIMIT_TIME_REAL_CRON=$intLimiteTimeRealCron
+            - SERVER_WIDE_MODULES=$strServerWideModules
+            - FILESTORE_COPY_HARD_LINK=True
+            - FILESTORE_OPERATIONS_THREADS=3
+            {{- if eq .Values.enumSessionsStore "redis" }}
+            - ENABLE_REDIS=True
+            - REDIS_HOST=$strRedisHost
+            - REDIS_PORT=6379
+            - REDIS_PASS=$strRedisPass
+            - REDIS_DBINDEX=1
+            {{- end}}
+    {{- if ne .Values.strGCECloudsqlConnectionName "" }}
+    gce-psql-proxy:
+        image: gcr.io/cloudsql-docker/gce-proxy:1.11
+        network_mode: container:odoo
+        command:
+            - /cloud_sql_proxy
+            - -instances=$strGCECloudsqlConnectionName=tcp:5432
+        # labels:
+        #    io.rancher.scheduler.affinity:container_label: io.rancher.stack_service.name=$${stack_name}/odoo
+    {{- end}}
+volumes:
+  {{- if eq .Values.enumSessionsStore "filestore" }}
+  $strOdooSessionsVolumeName:
+    driver: rancher-nfs
+    external: true
+  {{- end}}
+  $strOdooFilestoreVolumeName:
+    driver: rancher-nfs
+    external: true

--- a/templates/adhoc-odoo/17/rancher-compose.yml
+++ b/templates/adhoc-odoo/17/rancher-compose.yml
@@ -1,0 +1,322 @@
+version: '2'
+
+catalog:
+  name: "Druidoo Odoo"
+  version: "2.0"
+  description: "All-in-one management software"
+  minimum_rancher_version: v1.3.2
+  questions:
+
+# Docker image config
+
+    - variable: strImageTag
+      label: "Odoo Image Tag"
+      type: "string"
+      required: true
+      default: "12.0.druidoo"
+
+    - variable: strImageName
+      label: "Odoo Image Name"
+      description: "For eg. druidoo/odoo-druidoo"
+      type: "string"
+      required: true
+
+# domains configuration
+
+    - variable: strTraefikDomains
+      label: "Server names"
+      description: "A comma (,) separated and terminated list of max 8 domain names for alternate access to Odoo instance. E.g. ourodoo.acme.com,www.acme.org;"
+      type: "string"
+      required: true
+      default: ""
+
+    - variable: strTraefikRedirectRegex
+      label: "Redirect Regex"
+      description: "Redirect to another URL for that frontend. Must be set with Redirect Replacement"
+      type: "string"
+      required: false
+      default: ""
+
+    - variable: strTraefikRedirectReplacement
+      label: "Redirect Replacement"
+      description: "Redirect to another URL for that frontend. Must be set with Redirect Regex"
+      type: "string"
+      required: false
+      default: ""
+
+    # TODO we would like to build this with the stack name + traefik domain 
+    - variable: strMailCatchallDomain
+      label: "Mail Catchall Domain"
+      description: "Domain used for catchall, usually same domain as instance domain"
+      type: "string"
+      required: false
+      default: ""
+
+# odoo configuration parameters
+
+    - variable: strServerWideModules
+      label: "Server-wide modules."
+      type: "string"
+      required: true
+      default: "base,web,server_mode,saas_client"
+
+    - variable: strAdminPassword
+      label: "Odoo ADMIN_PASSWORD"
+      description: "Odoo ADMIN_PASSWORD environment var"
+      type: "password"
+      required: true
+      default: "admin"
+
+    - variable: strDatabase
+      label: "Odoo DB Name"
+      description: "The Odoo PostgreSQL database to be created on deploy. If none is set, then no database is created"
+      type: "string"
+      required: false
+      # required: true
+      # default: "default"
+
+    - variable: strDbFilter
+      label: "Odoo DB Filter"
+      description: "Regexp for Filter listed databases. For exact name use, for eg 'odoo$' for odoo db"
+      type: "string"
+      required: true
+      default: ".*"
+
+    - variable: strPgUser
+      label: "Postgres User"
+      description: "Postgres user"
+      type: "string"
+      required: true
+      default: "odoo"
+
+    - variable: intDbMaxconn
+      label: "Odoo Max Connections"
+      type: "int"
+      required: true
+      default: "100"
+
+    - variable: intLimitMemorySoft
+      label: "Limit Memory Soft"
+      description: "Maximum allowed virtual memory per worker, when reached the worker be reset after the current request"
+      type: "int"
+      required: true
+      # Este valor es el que usa odoo por defecto (odoo.py) y parecido al que
+      # sugiere la conf 629145600, usamos el por defecto
+      default: "671088640"
+      # este es el que veníamos usando
+      # default: "2147483648"
+
+    - variable: intLimitMemoryHard
+      label: "Limit Memory Hard"
+      description: "Maximum allowed virtual memory per worker, when reached, any memory allocation will fail"
+      type: "int"
+      required: true
+      # Este valor es el que usa odoo por defecto (odoo.py) pero parece
+      # que quedó viejo respecto a sugerencias más nuevas de usar algo más alto
+      # de 1 gb o más para que el proceso siga
+      # default: "805306368"
+      # sugerencias nuevas en deplo v11
+      # default: "1677721600"
+      # número que usabamos antes, lo dejamos para no limitar por ahora si hay
+      # alguna operación que use demasiada ram (ej. boggio)
+      default: "2147483648"
+
+    - variable: intLimiteTimeCpu
+      label: "Limit Time CPU"
+      description: "Maximum allowed CPU time per request"
+      type: "int"
+      required: true
+      default: "400"
+
+    - variable: intLimiteTimeReal
+      label: "Limit Time Real"
+      description: "Maximum allowed Real time per request"
+      type: "int"
+      required: true
+      default: "800"
+
+    - variable: intLimiteTimeRealCron
+      label: "Limit Time Real (only v11+)"
+      description: "Maximum allowed Real time per cron job. (default: --limit-time-real). Set to 0 for no limit."
+      type: "int"
+      required: true
+      default: "1600"
+
+    - variable: strDisableSessionGC
+      label: "Disable Odoo Sessions Garbage Collector"
+      type: "string"
+      required: false
+
+    - variable: strPgPassword
+      label: "Postgres Password"
+      description: "Postgres Password"
+      type: "password"
+      required: true
+
+    - variable: strPgHost
+      label: "Postgres Host"
+      description: "Postgres Host"
+      type: "string"
+      required: true
+
+    - variable: strPgPort
+      label: "Postgres Port"
+      description: "Postgres Port"
+      type: "int"
+      required: true
+      default: "5432"
+
+    - variable: strGCECloudsqlConnectionName
+      label: "GCE Instance connection name"
+      description: "If you set a value here a sidekick with cloudsql proxy will be configured to the configured Instance connection name"
+      type: "string"
+
+    - variable: strServerMode
+      label: "Odoo SERVER_MODE"
+      description: "Odoo SERVER_MODE environment var (leave empty for production environment)"
+      type: "string"
+      required: false
+      default: ""
+
+    - variable: intWorkers
+      label: "Odoo WORKERS"
+      description: "Odoo WORKERS environment var"
+      type: "int"
+      required: true
+      default: "0"
+
+    - variable: intMaxCronThreads
+      label: "Maximum Cron Threads"
+      description: "Maximum number of threads processing concurrently cron jobs"
+      type: "int"
+      required: true
+      default: "1"
+
+    - variable: strFixDbs
+      label: "FIX DBS"
+      description: "Try to fix database before starting odoo. You can send ',' sep. list or True to fix all available dbs."
+      type: "string"
+      required: false
+
+    - variable: strOdooDataFilestore
+      label: "Odoo Filestore Path"
+      type: "string"
+      required: true
+      default: "/opt/odoo/data/filestore/"
+
+    - variable: strOdooFilestoreVolumeName
+      label: "Odoo Filestore Volumen Name"
+      required: true
+      default: "odoo_data_filestore"
+      type: "string"
+
+    - variable: "enumSessionsStore"
+      label: "Store sessions on:"
+      type: enum
+      default: "filestore"
+      options:
+        - filestore
+        - redis
+
+    - variable: strRedisHost
+      label: "Redis Host"
+      description: "Required if Store Session on Redis"
+      type: "string"
+      required: false
+
+    - variable: strRedisPass
+      label: "Redis Password (optional)"
+      type: "string"
+      required: false
+      default: "False"
+
+    - variable: strOdooDataSessions
+      label: "Odoo Sessions Path"
+      description: "Required if Store Session on Filestore"
+      type: "string"
+      required: false
+      default: "/opt/odoo/data/sessions/"
+
+    - variable: strOdooSessionsVolumeName
+      label: "Odoo Sessions Volumen Name"
+      description: "Required if Store Session on Filestore"
+      required: false
+      default: "odoo_data_sessions"
+      type: "string"
+
+    - variable: boolListDb
+      label: "LIST DBs"
+      type: "boolean"
+      required: false
+      default: True
+
+# SMTP config
+
+    - variable: strSmtpServer
+      label: "SMTP Server"
+      type: "string"
+      required: false
+      default: "smtp.mailgun.org"
+
+    - variable: intSmtPort
+      label: "SMTP Port"
+      type: "int"
+      required: false
+      default: "25"
+
+    - variable: boolSmtpSsl
+      label: "SMTP SSL"
+      type: "boolean"
+      required: false
+      default: False
+
+    - variable: strSmtpUser
+      label: "SMTP User"
+      type: "string"
+      required: false
+
+    - variable: strSmtPassword
+      label: "SMTP Password"
+      type: "password"
+      required: false
+
+    - variable: "host_label"
+      description: "Host label where to run odoongins service."
+      label: "Host label:"
+      required: true
+      default: "odoo=true"
+      type: "string"
+
+# Custom Environment Variables
+
+    - variable: multiEnvVariables
+      label: "Environment Variables"
+      description: "ENV1: 'val1' (one per line)"
+      type: multiline
+
+# Custom Repositories on entrypoint
+# strReposYml is deprecated. Use multiReposYaml without url-encode instead
+
+    - variable: "strReposYml"
+      label: "Git Aggregator repos.yml "
+      description: "Deprecated. Use non-urlencoded multiReposYaml instead."
+      required: false
+      type: "string"
+
+    - variable: multiReposYaml
+      label: "Git Aggregator repos.yml"
+      description: "Custom repositories to be aggregated on entrypoint."
+      type: multiline
+
+#scaling and health checks per service as per docker-compose.yml
+services:
+  odoo:
+    health_check:
+      port: 8069
+      interval: 2000
+      unhealthy_threshold: 3
+      strategy: recreate
+      healthy_threshold: 2
+      response_timeout: 2000
+    upgrade_strategy:
+      start_first: true

--- a/templates/adhoc-odoo/17/rancher-compose.yml
+++ b/templates/adhoc-odoo/17/rancher-compose.yml
@@ -1,8 +1,8 @@
 version: '2'
 
 catalog:
-  name: "Druidoo Odoo"
-  version: "2.0"
+  name: "Odoo SaaS"
+  version: "12.5"
   description: "All-in-one management software"
   minimum_rancher_version: v1.3.2
   questions:
@@ -13,11 +13,11 @@ catalog:
       label: "Odoo Image Tag"
       type: "string"
       required: true
-      default: "12.0.druidoo"
+      default: "12.0"
 
     - variable: strImageName
       label: "Odoo Image Name"
-      description: "For eg. druidoo/odoo-druidoo"
+      description: "For eg. adhoc/odoo-saas"
       type: "string"
       required: true
 
@@ -178,6 +178,22 @@ catalog:
       required: false
       default: ""
 
+    - variable: "enumLogLevel"
+      label: "Log Level"
+      type: enum
+      default: "info"
+      options:
+        - critical
+        - error
+        - warn
+        - info
+        - test
+        - debug
+        - debug_rpc
+        - debug_sql
+        - debug_rpc_answer
+        - notset
+
     - variable: intWorkers
       label: "Odoo WORKERS"
       description: "Odoo WORKERS environment var"
@@ -193,7 +209,13 @@ catalog:
       default: "1"
 
     - variable: strFixDbs
-      label: "FIX DBS"
+      label: "FIX DBS (click-odoo-update)"
+      description: "Try to fix database before starting odoo."
+      type: "string"
+      required: false
+
+    - variable: strFixDbsAdhoc
+      label: "FIX DBS (Adhoc)"
       description: "Try to fix database before starting odoo. You can send ',' sep. list or True to fix all available dbs."
       type: "string"
       required: false

--- a/templates/adhoc-odoo/17/rancher-compose.yml
+++ b/templates/adhoc-odoo/17/rancher-compose.yml
@@ -9,17 +9,17 @@ catalog:
 
 # Docker image config
 
-    - variable: strImageTag
-      label: "Odoo Image Tag"
-      type: "string"
-      required: true
-      default: "12.0"
-
     - variable: strImageName
       label: "Odoo Image Name"
       description: "For eg. adhoc/odoo-saas"
       type: "string"
       required: true
+
+    - variable: strImageTag
+      label: "Odoo Image Tag"
+      type: "string"
+      required: true
+      default: "12.0"
 
 # domains configuration
 
@@ -52,13 +52,7 @@ catalog:
       required: false
       default: ""
 
-# odoo configuration parameters
-
-    - variable: strServerWideModules
-      label: "Server-wide modules."
-      type: "string"
-      required: true
-      default: "base,web,server_mode,saas_client"
+# Odoo Configuration
 
     - variable: strAdminPassword
       label: "Odoo ADMIN_PASSWORD"
@@ -66,6 +60,37 @@ catalog:
       type: "password"
       required: true
       default: "admin"
+
+    - variable: strServerWideModules
+      label: "Server-wide modules."
+      type: "string"
+      required: true
+      default: "base,web,server_mode,saas_client"
+
+    - variable: strServerMode
+      label: "Odoo SERVER_MODE"
+      description: "Odoo SERVER_MODE environment var (leave empty for production environment)"
+      type: "string"
+      required: false
+      default: ""
+
+    - variable: "enumLogLevel"
+      label: "Log Level"
+      type: enum
+      default: "info"
+      options:
+        - critical
+        - error
+        - warn
+        - info
+        - test
+        - debug
+        - debug_rpc
+        - debug_sql
+        - debug_rpc_answer
+        - notset
+
+# Database Configuration
 
     - variable: strDatabase
       label: "Odoo DB Name"
@@ -75,13 +100,6 @@ catalog:
       # required: true
       # default: "default"
 
-    - variable: strDbFilter
-      label: "Odoo DB Filter"
-      description: "Regexp for Filter listed databases. For exact name use, for eg 'odoo$' for odoo db"
-      type: "string"
-      required: true
-      default: ".*"
-
     - variable: strPgUser
       label: "Postgres User"
       description: "Postgres user"
@@ -89,11 +107,52 @@ catalog:
       required: true
       default: "odoo"
 
+    - variable: strPgPassword
+      label: "Postgres Password"
+      description: "Postgres Password"
+      type: "password"
+      required: true
+
+    - variable: strPgHost
+      label: "Postgres Host"
+      description: "Postgres Host"
+      type: "string"
+      required: true
+
+    - variable: strPgPort
+      label: "Postgres Port"
+      description: "Postgres Port"
+      type: "int"
+      required: true
+      default: "5432"
+
     - variable: intDbMaxconn
       label: "Odoo Max Connections"
       type: "int"
       required: true
       default: "100"
+
+    - variable: strDbFilter
+      label: "Odoo DB Filter"
+      description: "Regexp for Filter listed databases. For exact name use, for eg 'odoo$' for odoo db"
+      type: "string"
+      required: true
+      default: ".*"
+
+    - variable: boolListDb
+      label: "LIST DBs"
+      type: "boolean"
+      required: false
+      default: True
+
+# Performance Configuration
+
+    - variable: intWorkers
+      label: "Odoo WORKERS"
+      description: "Odoo WORKERS environment var"
+      type: "int"
+      required: true
+      default: "0"
 
     - variable: intLimitMemorySoft
       label: "Limit Memory Soft"
@@ -147,66 +206,14 @@ catalog:
       type: "string"
       required: false
 
-    - variable: strPgPassword
-      label: "Postgres Password"
-      description: "Postgres Password"
-      type: "password"
-      required: true
-
-    - variable: strPgHost
-      label: "Postgres Host"
-      description: "Postgres Host"
-      type: "string"
-      required: true
-
-    - variable: strPgPort
-      label: "Postgres Port"
-      description: "Postgres Port"
-      type: "int"
-      required: true
-      default: "5432"
-
-    - variable: strGCECloudsqlConnectionName
-      label: "GCE Instance connection name"
-      description: "If you set a value here a sidekick with cloudsql proxy will be configured to the configured Instance connection name"
-      type: "string"
-
-    - variable: strServerMode
-      label: "Odoo SERVER_MODE"
-      description: "Odoo SERVER_MODE environment var (leave empty for production environment)"
-      type: "string"
-      required: false
-      default: ""
-
-    - variable: "enumLogLevel"
-      label: "Log Level"
-      type: enum
-      default: "info"
-      options:
-        - critical
-        - error
-        - warn
-        - info
-        - test
-        - debug
-        - debug_rpc
-        - debug_sql
-        - debug_rpc_answer
-        - notset
-
-    - variable: intWorkers
-      label: "Odoo WORKERS"
-      description: "Odoo WORKERS environment var"
-      type: "int"
-      required: true
-      default: "0"
-
     - variable: intMaxCronThreads
       label: "Maximum Cron Threads"
       description: "Maximum number of threads processing concurrently cron jobs"
       type: "int"
       required: true
       default: "1"
+
+# Entrypoint Odoo-SaaS
 
     - variable: strFixDbs
       label: "FIX DBS (click-odoo-update)"
@@ -219,6 +226,22 @@ catalog:
       description: "Try to fix database before starting odoo. You can send ',' sep. list or True to fix all available dbs."
       type: "string"
       required: false
+
+# Custom Repositories on entrypoint
+# strReposYml is deprecated. Use multiReposYaml without url-encode instead
+
+    - variable: "strReposYml"
+      label: "Git Aggregator repos.yml "
+      description: "Deprecated. Use non-urlencoded multiReposYaml instead."
+      required: false
+      type: "string"
+
+    - variable: multiReposYaml
+      label: "Git Aggregator repos.yml"
+      description: "Custom repositories to be aggregated on entrypoint."
+      type: multiline
+
+# Filestore / Sessions
 
     - variable: strOdooDataFilestore
       label: "Odoo Filestore Path"
@@ -266,11 +289,12 @@ catalog:
       default: "odoo_data_sessions"
       type: "string"
 
-    - variable: boolListDb
-      label: "LIST DBs"
-      type: "boolean"
-      required: false
-      default: True
+# Other configurations
+
+    - variable: strGCECloudsqlConnectionName
+      label: "GCE Instance connection name"
+      description: "If you set a value here a sidekick with cloudsql proxy will be configured to the configured Instance connection name"
+      type: "string"
 
 # SMTP config
 
@@ -314,20 +338,6 @@ catalog:
     - variable: multiEnvVariables
       label: "Environment Variables"
       description: "ENV1: 'val1' (one per line)"
-      type: multiline
-
-# Custom Repositories on entrypoint
-# strReposYml is deprecated. Use multiReposYaml without url-encode instead
-
-    - variable: "strReposYml"
-      label: "Git Aggregator repos.yml "
-      description: "Deprecated. Use non-urlencoded multiReposYaml instead."
-      required: false
-      type: "string"
-
-    - variable: multiReposYaml
-      label: "Git Aggregator repos.yml"
-      description: "Custom repositories to be aggregated on entrypoint."
       type: multiline
 
 #scaling and health checks per service as per docker-compose.yml

--- a/templates/adhoc-odoo/config.yml
+++ b/templates/adhoc-odoo/config.yml
@@ -1,6 +1,6 @@
-name: ADHOC Odoo 9.0/11.0
+name: Odoo SaaS
 description: |
-  Odoo v9.0/11.0 customized by ADHOC
+  Odoo SaaS
 version: 5.1
 category: ERP
-projectURL: https://bitbucket.org/ingadhoc/rancher-catalog
+projectURL: https://github.com/ingadhoc/rancher-catalog

--- a/templates/adhoc-odoo/config.yml
+++ b/templates/adhoc-odoo/config.yml
@@ -1,6 +1,6 @@
 name: Odoo SaaS
 description: |
   Odoo SaaS
-version: 5.1
+version: 12.5
 category: ERP
 projectURL: https://github.com/ingadhoc/rancher-catalog


### PR DESCRIPTION
La idea es que esta versión nos sirva para integrar el rancher-catalog.

Algunos cambios:
- ADD variable for log_level
- ADD variable for REPOS_YAML (que va a reemplazar a REPOS_YML, por ahora todavía disponible)
- ADD variable for custom ENV variables

La más importante para unificarnos es la de las custom env variables.
La idea es que con esto podamos enviar configurar y enviar variables de entorno en los distintos objectos de saas_provider.
