### PR TITLE
Bump traefik to 1.7.24

### DIFF
--- a/templates/adhoc-aeroo-docs/config.yml
+++ b/templates/adhoc-aeroo-docs/config.yml
@@ -3,4 +3,4 @@ description: |
   Aeroo Docs Stack used to convert openoffice docs to pdf or office format
 version: 1.0
 category: ERP
-projectURL: https://bitbucket.org/ingadhoc/rancher-catalog
+projectURL: https://github.com/ingadhoc/rancher-catalog

--- a/templates/adhoc-grafana/config.yml
+++ b/templates/adhoc-grafana/config.yml
@@ -3,4 +3,4 @@ description: |
   Grafana Catalog by ADHOC
 version: 1.0
 category: Monitoring
-projectURL: https://bitbucket.org/ingadhoc/rancher-catalog
+projectURL: https://github.com/ingadhoc/rancher-catalog

--- a/templates/adhoc-odoo-postfix/config.yml
+++ b/templates/adhoc-odoo-postfix/config.yml
@@ -3,4 +3,4 @@ description: |
   Postfix stack used to deliver mails to odoo stacks and also to send emails from stacks
 version: 1.0
 category: ERP
-projectURL: https://bitbucket.org/ingadhoc/rancher-catalog
+projectURL: https://github.com/ingadhoc/rancher-catalog

--- a/templates/adhoc-pgadmin4/config.yml
+++ b/templates/adhoc-pgadmin4/config.yml
@@ -3,4 +3,4 @@ description: |
   Pgadmin4 Catalog by ADHOC
 version: 1.0
 category: Monitoring
-projectURL: https://bitbucket.org/ingadhoc/rancher-catalog
+projectURL: https://github.com/ingadhoc/rancher-catalog

--- a/templates/adhoc-postgres/config.yml
+++ b/templates/adhoc-postgres/config.yml
@@ -3,3 +3,4 @@ description: |
   PostgreSQL — an object-relational database (ORDBMS)
 version: v0.0.5
 category: Databases
+projectURL: https://github.com/ingadhoc/rancher-catalog

--- a/templates/adhoc-traefik/11/README.md
+++ b/templates/adhoc-traefik/11/README.md
@@ -1,0 +1,13 @@
+## ADHOC Traefik Active Load Balanceer
+
+### Configuration Items
+
+Hay que crear volumen externo llamado "secrets"
+
+Por ahora hace falta subir a mano al volumen certificados en /secrets/domain.crt  y /secrets/domain.key
+También hay que crear un archivo limpio /secrets/acme.json y ponerle permisos "600"
+
+Para que ande hay que modificar el arranque la primera vez y sacar lo de https, se crea el directorio, se agrega lo anteror y luego se actualiza
+
+
+NOTA IMPORTANTE: para cmabiar de dns challenge a http o viceversa, hay que borrar la carpeta de consul del que no se quiere usar mas y luego hacer el upgrade

--- a/templates/adhoc-traefik/11/docker-compose.yml.tpl
+++ b/templates/adhoc-traefik/11/docker-compose.yml.tpl
@@ -1,0 +1,50 @@
+version: '2'
+services:
+    traefik:
+        tty: true
+        stdin_open: true
+        ports:
+            - ${admin_port}:8080/tcp
+            - ${http_port}:80/tcp
+            - ${https_port}:443/tcp
+        {{- if and (eq .Values.acme_http_challenge "false") (ne .Values.acme_dns_challenge "gcloud")}}
+        command: sh -c "traefik storeconfig --api.dashboard --checknewversion=false --rancher --rancher.domain=${domain} --rancher.metadata --rancher.enableservicehealthfilter=${EnableServiceHealthFilter} --logLevel=INFO --defaultentrypoints=http,https --insecureskipverify=true '--entryPoints=Name:http Address::80 Redirect.EntryPoint:https' '--entryPoints=Name:https Address::443 TLS Compress:on' --acme --acme.acmelogging --acme.entrypoint=https --acme.httpChallenge.entryPoint= --acme.dnschallenge.provider= --acme.email=${acme_email} --acme.onhostrule=${acme_onhostrule} --acme.storage=traefik/acme/account --consul.endpoint=${ConsulEndpoint} && traefik --consul --consul.endpoint=${ConsulEndpoint}"
+        {{- end}}
+        {{- if eq .Values.acme_http_challenge "true"}}
+        command: sh -c "traefik storeconfig --api.dashboard --checknewversion=false --rancher --rancher.domain=${domain} --rancher.metadata --rancher.enableservicehealthfilter=${EnableServiceHealthFilter} --logLevel=INFO --defaultentrypoints=http,https --insecureskipverify=true '--entryPoints=Name:http Address::80 Redirect.EntryPoint:https' '--entryPoints=Name:https Address::443 TLS Compress:on' --acme --acme.acmelogging --acme.entrypoint=https --acme.email=${acme_email} --acme.onhostrule=${acme_onhostrule} --acme.storage=traefik/acme/account --acme.httpChallenge --acme.httpChallenge.entryPoint=http --consul.endpoint=${ConsulEndpoint} && traefik --consul --consul.endpoint=${ConsulEndpoint}"
+        {{- end}}
+        {{- if eq .Values.acme_dns_challenge "gcloud"}}
+        command: sh -c "traefik storeconfig --api.dashboard --checknewversion=false --rancher --rancher.domain=${domain} --rancher.metadata --rancher.enableservicehealthfilter=${EnableServiceHealthFilter} --logLevel=INFO --defaultentrypoints=http,https --insecureskipverify=true '--entryPoints=Name:http Address::80 Redirect.EntryPoint:https' '--entryPoints=Name:https Address::443 TLS Compress:on' --acme --acme.acmelogging --acme.entrypoint=https --acme.email=${acme_email} --acme.onhostrule=${acme_onhostrule} --acme.storage=traefik/acme/account --acme.dnschallenge --acme.domains=*.${domain} --acme.dnschallenge.provider=gcloud --acme.dnschallenge.delaybeforecheck=180 --consul.endpoint=${ConsulEndpoint} && traefik --consul --consul.endpoint=${ConsulEndpoint}"
+        {{- end}}
+        {{- if eq .Values.acme_dns_challenge "cloudflare"}}
+        command: sh -c "traefik storeconfig --api.dashboard --checknewversion=false --rancher --rancher.domain=${domain} --rancher.metadata --rancher.enableservicehealthfilter=${EnableServiceHealthFilter} --logLevel=INFO --defaultentrypoints=http,https --insecureskipverify=true '--entryPoints=Name:http Address::80 Redirect.EntryPoint:https' '--entryPoints=Name:https Address::443 TLS Compress:on' --acme --acme.acmelogging --acme.entrypoint=https --acme.email=${acme_email} --acme.onhostrule=${acme_onhostrule} --acme.storage=traefik/acme/account --acme.dnschallenge --acme.domains=*.${domain} --acme.dnschallenge.provider=cloudflare --acme.dnschallenge.delaybeforecheck=180 --consul.endpoint=${ConsulEndpoint} && traefik --consul --consul.endpoint=${ConsulEndpoint}"
+        {{- end}}
+        # por ahora traefik no soporta los dos challenge a la vez pero puede ser que mas adelante si, ver acá https://github.com/containous/traefik/issues/3378
+        {{- if eq .Values.acme_dns_challenge "cloudflare"}}
+        environment:
+            CF_API_KEY: ${acme_dns_challenge_CF_API_KEY}
+            CF_API_EMAIL: ${acme_dns_challenge_CF_API_EMAIL}
+        {{- end}}
+        {{- if eq .Values.acme_dns_challenge "gcloud"}}
+        environment:
+            GCE_PROJECT: ${acme_dns_challenge_GCE_PROJECT}
+            GCE_SERVICE_ACCOUNT_FILE: ${acme_dns_challenge_GCE_SERVICE_ACCOUNT_FILE}
+        {{- end}}
+        labels:
+            # por ahora no lo hacemos global y lo manejamos con scale y host distinto
+            # io.rancher.scheduler.affinity:container_label_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
+            # io.rancher.scheduler.global: 'false'
+            io.rancher.scheduler.global: 'true'
+            io.rancher.scheduler.affinity:host_label: ${host_label}
+            # publish traefik admin
+            traefik.enable: 'true'
+            traefik.port: 8080
+            traefik.frontend.auth.basic.users: "${auth_users}"
+            traefik.frontend.rule: "Host:tr.${domain}"
+        image: traefik:1.7.8-alpine
+        volumes:
+            - traefik-secrets:/secrets
+volumes:
+    traefik-secrets:
+        driver: rancher-nfs
+        external: true

--- a/templates/adhoc-traefik/11/docker-compose.yml.tpl
+++ b/templates/adhoc-traefik/11/docker-compose.yml.tpl
@@ -41,7 +41,7 @@ services:
             traefik.port: 8080
             traefik.frontend.auth.basic.users: "${auth_users}"
             traefik.frontend.rule: "Host:tr.${domain}"
-        image: traefik:1.7.8-alpine
+        image: traefik:1.7.24-alpine
         volumes:
             - traefik-secrets:/secrets
 volumes:

--- a/templates/adhoc-traefik/11/rancher-compose.yml
+++ b/templates/adhoc-traefik/11/rancher-compose.yml
@@ -1,6 +1,6 @@
 .catalog:
   name: "Adhoc Traefik Global Con Consul"
-  version: "1.7.9"
+  version: "1.7.24"
   description: "(Experimental) Traefik load balancer."
   minimum_rancher_version: v1.3.2
   questions:

--- a/templates/adhoc-traefik/11/rancher-compose.yml
+++ b/templates/adhoc-traefik/11/rancher-compose.yml
@@ -1,0 +1,181 @@
+.catalog:
+  name: "Adhoc Traefik Global Con Consul"
+  version: "1.7.9"
+  description: "(Experimental) Traefik load balancer."
+  minimum_rancher_version: v1.3.2
+  questions:
+
+    - variable: "auth_users"
+      label: "Traefik administration Users."
+      description: "CSV format: User:Hash,User:Hash. Administration panel is on tr.{domain}. You can generate in here https://www.web2generators.com/apache-tools/htpasswd-generator"
+      required: true
+      type: "string"
+
+    - variable: "http_port"
+      description: "Traefik http public port to listen."
+      label: "Http port:"
+      required: true
+      default: 80
+      type: "int"
+
+    - variable: "https_port"
+      description: "Traefik https public port to listen."
+      label: "Https port:"
+      required: true
+      default: 443
+      type: "int"
+
+    - variable: "admin_port"
+      description: "Traefik admin public port to listen."
+      label: "Admin port:"
+      required: true
+      default: 8000
+      type: "int"
+
+    - variable: "domain"
+      description: "Can be overridden by setting the 'traefik.domain' label on an service."
+      label: "Default domain used:"
+      required: true
+      default: "rancher.localhost"
+      type: "string"
+
+    - variable: "ConsulEndpoint"
+      label: "Consul Endpoint:"
+      required: true
+      default: "adhoc-consul-consul-1:8500"
+      type: "string"
+
+    - variable: "EnableServiceHealthFilter"
+      label: "Enable Service Health Filter:"
+      required: false
+      # por ahora sugerimos que si si no da error al restaurar backups. Luego, si queremos actualizar online, tal vez tengamos que desactivarlo
+      default: true
+      type: "boolean"
+
+    - variable: "host_label"
+      description: "Host label where to run traefik service."
+      label: "Host label:"
+      required: true
+      default: "traefik_lb=true"
+      type: "string"
+
+    # TODO enable this
+    # - variable: "RefreshSeconds"
+    #   label: "Polling interval (in seconds):"
+    #   required: true
+    #   default: 15
+    #   type: "int"
+
+    # - variable: "ExposedByDefault"
+    #   description: "Expose Rancher services by default in traefik."
+    #   label: "Expose by Default:"
+    #   required: false
+    #   default: false
+    #   type: "boolean"
+
+    # - variable: "EnableServiceHealthFilter"
+    #   description: "Filter services with unhealthy states and health states."
+    #   label: "Enable Service Health Filter:"
+    #   required: false
+    #   default: false
+    #   type: "boolean"
+
+    # por ahora no es opcional, es obligatorio
+    # - variable: "https_enable"
+    #   label: "Enable HTTPS:"
+    #   description: |
+    #     Enable https working mode. If you activate, you need to fill SSL key and SSL crt in order to work.
+    #   default: false
+    #   required: false
+    #   type: "boolean"
+
+    # TODO implementar, por ahora las ponemos a mano
+    # - variable: "ssl_key"
+    #   description: "SSL key to secure the service. *Required if you enable https"
+    #   label: "SSL key"
+    #   type: "multiline"
+    #   required: false
+    #   default: ""
+
+    # - variable: "ssl_crt"
+    #   description: "SSL cert to secure the service. *Required if you enable https"
+    #   label: "SSL crt"
+    #   type: "multiline"
+    #   required: false
+    #   default: ""
+
+    # COMO ahora va todo como un command se hace mas dificil activar / desactivar
+    # - variable: "acme_enable"
+    #   description: "Enable acme support on traefik."
+    #   label: "Enable ACME:"
+    #   required: true
+    #   default: false
+    #   type: "boolean"
+
+    - variable: "acme_http_challenge"
+      label: "Enable HTTP Challenge Over http"
+      required: true
+      default: false
+      type: "boolean"
+
+    - variable: "acme_dns_challenge"
+      label: "Enable DNS Challenge"
+      type: enum
+      options:
+        - gcloud
+        - route53
+        - cloudflare
+
+    - variable: "acme_dns_challenge_GCE_PROJECT"
+      label: "Gcloud DNS challenge GCE_PROJECT"
+      type: "string"
+
+    - variable: "acme_dns_challenge_GCE_SERVICE_ACCOUNT_FILE"
+      label: "Gcloud DNS challenge GCE_SERVICE_ACCOUNT_FILE"
+      type: "string"
+
+    - variable: "acme_dns_challenge_CF_API_KEY"
+      label: "Cloudflare DNS challenge CF_API_KEY"
+      type: "string"
+
+    - variable: "acme_dns_challenge_CF_API_EMAIL"
+      label: "Cloudflare DNS challenge CF_API_EMAIL"
+      type: "string"
+
+    - variable: "acme_email"
+      description: "ACME user email."
+      label: "ACME email:"
+      required: true
+      default: "test@traefik.io"
+      type: "string"
+
+    - variable: "acme_onhostrule"
+      description: "Enable acme onHostRule."
+      label: "ACME onHostRule:"
+      required: true
+      default: true
+      type: "boolean"
+
+#
+# Scaling and health checks per service as per docker-compose.yml
+#
+version: 2
+services:
+  traefik:
+    retain_ip: true
+    health_check:
+      port: 8080
+      interval: 5000
+      unhealthy_threshold: 3
+      request_line: 'GET /dashboard/# HTTP/1.0'
+      healthy_threshold: 2
+      response_timeout: 5000
+# esto podria llegar a usarse para que con algun curl o algo, en entrypoint
+# o algo asi, desde el metadata generemos los archivos
+# lo hacen con algo de aca https://github.com/rawmind0/rancher-traefik/blob/master/root/opt/tools/confd/etc/conf.d/traefik.key.toml
+  # metadata:
+  #   traefik:
+  #     ssl_key: |
+  #       ${ssl_key}
+  #     ssl_crt: |
+  #       ${ssl_crt}

--- a/templates/adhoc-traefik/config.yml
+++ b/templates/adhoc-traefik/config.yml
@@ -3,4 +3,4 @@ description: |
   Traefik Catalog by ADHOC
 version: 1.5.0
 category: Load Balancing
-projectURL: https://bitbucket.org/ingadhoc/rancher-catalog
+projectURL: https://github.com/ingadhoc/rancher-catalog


### PR DESCRIPTION
Nico nos hizo el upgrade aca, para ver si resuelve un problema que tenemos con traefik que cada 2 x 3 se olvida de renovar certificados.

Aprovecho a cambiarle el projectURL a los catalog para que apunten a github en lugar de bitbucket