### PR TITLE
[add]  shm option

### DIFF
--- a/templates/adhoc-postgres/6/docker-compose.yml
+++ b/templates/adhoc-postgres/6/docker-compose.yml
@@ -1,0 +1,51 @@
+version: '2'
+services:
+  postgres:
+    image: postgres:${POSTGRES_TAG}
+    environment:
+      PGDATA: /var/lib/postgresql/data/pgdata
+      POSTGRES_DB: ${postgres_db}
+      POSTGRES_USER: ${postgres_user}
+      POSTGRES_PASSWORD: ${postgres_password}
+      PGDATABASE: ${postgres_db}
+      PGUSER: ${postgres_user}
+      PGPASSWORD: ${postgres_password}
+      PGPORT: ${server_port}
+    tty: true
+    network_mode: host
+    stdin_open: true
+    oom_kill_disable: true
+    shm_size: ${shm_size}
+    command: docker-entrypoint.sh postgres -p ${server_port} -c max_connections=${max_connections} -c shared_buffers=${shared_buffers} -c work_mem=${work_mem} -c effective_cache_size=${effective_cache_size} ${server_configuration}
+    labels:
+      io.rancher.scheduler.affinity:host_label: ${host_label}
+    volumes:
+      - $volumen_name:/var/lib/postgresql/data/pgdata
+  pg-idle-killer:
+    image: postgres:${POSTGRES_TAG}
+    environment:
+      PGDATABASE: ${postgres_db}
+      PGUSER: ${postgres_user}
+      PGPASSWORD: ${postgres_password}
+      PGPORT: ${server_port}
+      PGHOST: pg
+    stdin_open: true
+    entrypoint:
+    - psql
+    - -c
+    - SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE pid <> pg_backend_pid() AND state = 'idle' AND state_change < current_timestamp - INTERVAL '30' MINUTE;
+    tty: true
+    links:
+    - postgres:pg
+    labels:
+      cron.schedule: '@every 30m'
+      cron.restart_timeout: '60'
+      cron.action: restart
+      io.rancher.scheduler.affinity:host_label: ${host_label}
+      io.rancher.container.start_once: 'true'
+volumes:
+  $volumen_name:
+    driver: local
+    # por seguridad para no perder si alguienb borra el stack, se debe crear con
+    # rancher volume create --driver local pgdata
+    external: true

--- a/templates/adhoc-postgres/6/rancher-compose.yml
+++ b/templates/adhoc-postgres/6/rancher-compose.yml
@@ -1,0 +1,107 @@
+version: '2'
+catalog:
+  name: "Postgres"
+  version: "v0.0.7"
+  description: "PostgreSQL with pg idle killer"
+  uuid: postgres-0
+  minimum_rancher_version: v0.9.0
+  questions:
+    - variable: volumen_name
+      label: "Volume Name"
+      description: "Volume Name where data will be stored. You need to create it with rancher volume create --driver local $volume_name"
+      required: true
+      default: ""
+      type: "string"
+    - variable: server_port
+      description: |
+        Port where postgres server will listen. Make sure host allow connections on that port. For eg. for port 5432 you can open them with this example
+        Example: iptables -I INPUT -p tcp --dport 5432 -j ACCEPT
+      label: "Server Port"
+      required: true
+      default: "5432"
+      type: "int"
+    - variable: postgres_db
+      description: "Postgres Database"
+      label: "Postgres Database"
+      required: true
+      default: "postgres"
+      type: "string"
+    - variable: postgres_user
+      description: "Postgres User"
+      label: "Postgres User"
+      required: true
+      default: "postgres_user"
+      type: "string"
+    - variable: postgres_password
+      description: "Postgres Password"
+      label: "Postgres Password"
+      required: true
+      default: "postgres_password"
+      type: "password"
+    - variable: "POSTGRES_TAG"
+      description: "The postgres tag to associate with this server. Choose any valid tag from https://hub.docker.com/_/postgres"
+      label: "Postgres tag"
+      required: true
+      default: "10"
+      type: "string"
+    - variable: host_label
+      label: "Host with Label to put postgres on"
+      description: |
+        Host label to use as postgres 'value' tag.
+        Example: 'postgres=true'
+      required: true
+      default: "pg=true"
+      type: "string"
+    - variable: max_connections
+      label: "Max Connections"
+      required: true
+      default: "1000"
+      type: "int"
+    - variable: shared_buffers
+      label: "Shared Buffers"
+      description: |
+        Odoo suggest more than 55% of ram on VM
+        Example: 35GB
+      required: true
+      default: ""
+      type: "string"
+    - variable: effective_cache_size
+      label: "Effective Cache Size"
+      description: |
+        Odoo suggest between 50% and 75% of ram (75 to aggressive)
+        Example: 30GB
+      required: true
+      default: ""
+      type: "string"
+    - variable: work_mem
+      label: "Work Mem"
+      description: "Odoo suggest to start with 64mb"
+      required: true
+      default: "64MB"
+      type: "string"
+    - variable: server_configuration
+      label: "Additional configuration parameters to be set"
+      description: |
+        List of additional configurations to be set. You can check for parameters suggestions on this site https://pgtune.leopard.in.ua/#/
+        Example: -c shared_buffers=256MB -c work_mem=64mb
+      required: false
+      default: ""
+      type: "string"
+    - variable: shm_size
+      label: "Container shared memory"
+      description: "Shared memory segments allocated by parallel query to communicate between parallel workers (when max_parallel_workers != 0) Their size depends on the data transferred, and several of them can be allocated, so that is a resource that is harder to control. But if you see errors like 'could not resize shared memory segment : No space left on device' you need to increase this value. Docker default 64mb"
+      required: true
+      default: "64mb"
+      type: "string"
+
+services:
+  postgres:
+    scale: 1
+    health_check:
+      port: ${server_port}
+      interval: 2000
+      unhealthy_threshold: 3
+      healthy_threshold: 2
+      response_timeout: 2000
+  pg-idle-killer:
+    scale: 1

--- a/templates/adhoc-postgres/config.yml
+++ b/templates/adhoc-postgres/config.yml
@@ -1,6 +1,6 @@
 name: ADHOC PostgreSQL
 description: |
   PostgreSQL — an object-relational database (ORDBMS)
-version: v0.0.6
+version: v0.0.7
 category: Databases
 projectURL: https://github.com/ingadhoc/rancher-catalog


### PR DESCRIPTION
En una vista pivot un poco compleja pg no podia asignar memoria compartida. Por defecto docker tiene el maximo en 64MB lo aumento a 256MB.

``` sql
ELECT min("account_invoice_report".id) AS id, count("account_invoice_report".id) AS "__count" , sum("account_invoice_report"."price_subtotal") AS "price_subtotal",array
_agg("account_invoice_report"."id") AS "ids",date_trunc('month', "account_invoice_report"."invoice_date"::timestamp) as "invoice_date" 
                   FROM "account_invoice_report"
                   WHERE ((("account_invoice_report"."state" not in ('draft','cancel')) OR "account_invoice_report"."state" IS NULL) AND (("account_invoice_report"."type" = 'out_invoice'
) OR ("account_invoice_report"."type" = 'out_refund'))) AND ("account_invoice_report"."company_id" IS NULL  OR ("account_invoice_report"."company_id" in (3)))
                   GROUP BY date_trunc('month', "account_invoice_report"."invoice_date"::timestamp)
                   ORDER BY "invoice_date"
```

``` log
  File "/home/odoo/src/odoo/odoo/sql_db.py", line 173, in wrapper
    return f(self, *args, **kwargs)
  File "/home/odoo/src/odoo/odoo/sql_db.py", line 250, in execute
    res = self._obj.execute(query, params)
psycopg2.OperationalError: could not resize shared memory segment "/PostgreSQL.1888923382" to 4194304 bytes: No space left on device
```

PG usa la memoria compartida en principalmente en 2 lugares:

* La memoria compartida del setting shared_buffers que se reserva al iniciar el servidor. (que no es la de este caso)
* Y los segmentos de memoria compartida que se reservan cuando se hacen consultas en paralelo (el setting max_parallel_workers debe ser distinto de 0). (sobretodo en consultas anidadas, etc) Esta memoria se utiliza para que los procesos en paralelo puedan comunicase entre si. El problema es que el tamaño depende de las consultas por lo que es difícil de determinar de antemano. Así que esté valor va a depender del uso. reservar de mas implica resignar memoria para el resto de las operaciones (ya q se asigna y se monta) 

El valor por defecto de docker es de 64MB que en general es suficiente. Para el problema puntual de arriba lo dejamos en 254MB solo en el servidor que lo necesitó.

